### PR TITLE
build: Simplify package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,21 +1,9 @@
 {
-  "name": "language-screenshots",
-  "version": "0.0.1",
-  "description": "",
-  "main": "index.js",
+  "private": true,
   "scripts": {
     "test": "grunt"
   },
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/zeljkofilipin/language-screenshots.git"
-  },
-  "author": "",
   "license": "MIT",
-  "bugs": {
-    "url": "https://github.com/zeljkofilipin/language-screenshots/issues"
-  },
-  "homepage": "https://github.com/zeljkofilipin/language-screenshots#readme",
   "dependencies": {
     "grunt": "^1.0.1",
     "grunt-jscs": "2.8.0",


### PR DESCRIPTION
Remove redundant properties that mainly relate to re-usable libraries
one would install from npm rather than Git, and configure later.

Also remove `main` property that points to non-existent `index.js`.
